### PR TITLE
Fix a problem in the TestRequest class

### DIFF
--- a/_test/core/TestRequest.php
+++ b/_test/core/TestRequest.php
@@ -40,11 +40,31 @@ class TestRequest {
     /**
      * Executes the request
      *
-     * @param string $url  end URL to simulate, needs to start with /doku.php currently
+     * @param string $uri
      * @return TestResponse the resulting output of the request
+     * @throws Exception
+     * @internal param string $url end URL to simulate, needs to start with /doku.php currently
      */
     public function execute($uri='/doku.php') {
         global $INPUT;
+        global $INFO;
+
+        // fix global scope because doku.php is being run inside a class function rather than in the global scope
+        if (!isset($GLOBALS['updateVersion'])) $GLOBALS['updateVersion'] = 0;
+        if (!isset($GLOBALS['QUERY'])) $GLOBALS['QUERY'] = '';
+        if (!isset($GLOBALS['ID'])) $GLOBALS['ID'] = '';
+        if (!isset($GLOBALS['REV'])) $GLOBALS['REV'] = 0;
+        if (!isset($GLOBALS['IDX'])) $GLOBALS['IDX'] = '';
+        if (!isset($GLOBALS['DATE'])) $GLOBALS['DATE'] = 0;
+        if (!isset($GLOBALS['RANGE'])) $GLOBALS['RANGE'] = '';
+        if (!isset($GLOBALS['HIGH'])) $GLOBALS['HIGH'] = '';
+        if (!isset($GLOBALS['TEXT'])) $GLOBALS['TEXT'] = '';
+        if (!isset($GLOBALS['PRE'])) $GLOBALS['PRE'] = '';
+        if (!isset($GLOBALS['SUF'])) $GLOBALS['SUF'] = '';
+        if (!isset($GLOBALS['SUM'])) $GLOBALS['SUM'] = '';
+        if (!isset($GLOBALS['JSINFO'])) $GLOBALS['JSINFO'] = array();
+
+        if (!isset($INFO['perm'])) $INFO['perm'] = AUTH_READ;
 
         // save old environment
         $server = $_SERVER;

--- a/_test/tests/test/basic.test.php
+++ b/_test/tests/test/basic.test.php
@@ -177,8 +177,7 @@ class InttestsBasicTest extends DokuWikiTest {
         $response = $request->get(array('id' => 'mailinglist'), '/doku.php');
 
         // output check
-        // 2015-07-03, Phil Hopper: this is silly and also failing
-        //$this->assertTrue(strpos($response->getContent(), 'Netiquette') !== false);
+        $this->assertTrue(strpos($response->getContent(), 'Netiquette') !== false);
     }
 
 }


### PR DESCRIPTION
doku.php is being included inside a class member function which causes variables
that were intended to be global actually being in the local function scope and
therefore not available later when being tested.
