### PR TITLE
Fix bug in regex that removes initial HTML comment

### DIFF
--- a/lib/plugins/door43obsdocupload/action/ExportButtons.php
+++ b/lib/plugins/door43obsdocupload/action/ExportButtons.php
@@ -97,9 +97,6 @@ class action_plugin_door43obsdocupload_ExportButtons extends Door43_Action_Plugi
 
         $html = file_get_contents(dirname(dirname(__FILE__)) . '/templates/obs_export_script.html');
 
-        // remove the initial doc comments
-        $html = preg_replace('/^\<!--(.|\n)*--\>(\n)/', '', $html, 1);
-
         echo $this->translateHtml($html);
     }
 

--- a/lib/plugins/door43register/action/RegisterOverride.php
+++ b/lib/plugins/door43register/action/RegisterOverride.php
@@ -129,9 +129,6 @@ class action_plugin_door43register_RegisterOverride extends DokuWiki_Action_Plug
         // remove suppress comments
         $buttonText = preg_replace('/\<!--(\s)*suppress(.)*--\>(\n)/', '', $buttonText, 1);
 
-        // remove the initial doc comments
-        $buttonText = preg_replace('/^\<!--(.|\n)*--\>(\n)/', '', $buttonText, 1);
-
         // translate
         $buttonText = $this->translateHtml($buttonText);
 

--- a/lib/plugins/door43shared/base_classes/plugin_base.php
+++ b/lib/plugins/door43shared/base_classes/plugin_base.php
@@ -139,9 +139,6 @@ class Door43_Syntax_Plugin extends DokuWiki_Syntax_Plugin {
         // Load the template for the button
         $text = file_get_contents($this->root . '/templates/' . $this->templateFileName);
 
-        // remove the initial doc comments
-        $text = preg_replace('/^\<!--(.|\n)*--\>(\n)/', '', $text, 1);
-
         $text = $this->translateHtml($text);
 
         return $text;

--- a/lib/plugins/door43shared/helper.php
+++ b/lib/plugins/door43shared/helper.php
@@ -46,6 +46,9 @@ class helper_plugin_door43shared extends DokuWiki_Plugin {
      */
     public function translateHtml($html, $langArray) {
 
+        // remove the initial doc comments
+        $html = preg_replace('/^\<!--(.|\n)*--\>(\n)/U', '', $html, 1);
+
         // replace all strings from the passed $langArray
         $temp = preg_replace_callback('/@(.+?)@/',
             function($matches) use ($langArray) {

--- a/lib/plugins/translation/helper.php
+++ b/lib/plugins/translation/helper.php
@@ -464,7 +464,7 @@ class helper_plugin_translation extends DokuWiki_Plugin {
         $html = file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'private' . DIRECTORY_SEPARATOR . 'html' . DIRECTORY_SEPARATOR . 'auto_complete_language.html');
 
         // remove the initial doc comments
-        $html = preg_replace('/^\<!--(\n|.)*?--\>(\n)?/', '', $html, 1);
+        $html = preg_replace('/^\<!--(\n|.)*?--\>(\n)?/U', '', $html, 1);
 
         // set id, name, style and class
         $html = str_replace('id=""', 'id="' . $id . '"', $html);


### PR DESCRIPTION
The regex was greedy, and if there were additional HTML comments, the code was
removing all text from the beginning of the string to the end of the last comment.

I also consolidated to minimize the number of places the regular expression is
found in the code.
