### PR TITLE
Fix Parser Media Tests

### DIFF
--- a/_test/tests/inc/parser/parser_media.test.php
+++ b/_test/tests/inc/parser/parser_media.test.php
@@ -30,12 +30,21 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $source = '<source src="http://some.where.far/away.ogv" type="video/ogg" />';
         $this->assertEquals(substr($url,67,64),$source);
         // work around random token
-        $a_first_part = '<a href="/tmp/lib/exe/fetch.php?cache=&amp;tok=';
+        $a_first_part = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?cache=&amp;tok=';
         $a_second_part = '&amp;media=http%3A%2F%2Fsome.where.far%2Faway.ogv" class="media mediafile mf_ogv" title="http://some.where.far/away.ogv">';
-        $this->assertEquals($a_first_part, substr($url,132,47));
-        $this->assertEquals($a_second_part, substr($url,185,121));
+
+        $substr_start = 132;
+        $substr_len = strlen($a_first_part);
+        $this->assertEquals($a_first_part, substr($url, $substr_start, $substr_len));
+
+        $substr_start = strpos($url, '&amp;media', $substr_start + $substr_len);
+        $this->assertNotSame(false, $substr_start, 'Substring not found.');
+        $substr_len = strlen($a_second_part);
+        $this->assertEquals($a_second_part, substr($url, $substr_start, $substr_len));
+
         $rest = 'away.ogv</a></video>'."\n";
-        $this->assertEquals($rest, substr($url,306));
+        $substr_start = strlen($url) - strlen($rest);
+        $this->assertEquals($rest, substr($url, $substr_start));
     }
 
     /**
@@ -58,12 +67,21 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $Renderer = new Doku_Renderer_xhtml();
         $url = $Renderer->externalmedia($file, null, null, null, null, 'cache', 'details', true);
         // work around random token
-        $a_first_part = '<a href="/tmp/lib/exe/fetch.php?tok=';
+        $a_first_part = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?tok=';
         $a_second_part = '&amp;media=http%3A%2F%2Fsome.where.far%2Faway.vid" class="media mediafile mf_vid" title="http://some.where.far/away.vid">';
-        $this->assertEquals($a_first_part, substr($url,0,36));
-        $this->assertEquals($a_second_part, substr($url,42,121));
+
+        $substr_start = 0;
+        $substr_len = strlen($a_first_part);
+        $this->assertEquals($a_first_part, substr($url, $substr_start, $substr_len));
+
+        $substr_start = strpos($url, '&amp;media', $substr_start + $substr_len);
+        $this->assertNotSame(false, $substr_start, 'Substring not found.');
+        $substr_len = strlen($a_second_part);
+        $this->assertEquals($a_second_part, substr($url, $substr_start, $substr_len));
+
         $rest = 'away.vid</a>';
-        $this->assertEquals($rest, substr($url,163));
+        $substr_start = strlen($url) - strlen($rest);
+        $this->assertEquals($rest, substr($url, $substr_start));
     }
 
 
@@ -84,20 +102,33 @@ class TestOfDoku_Parser_Media extends TestOfDoku_Parser {
         $Renderer = new Doku_Renderer_xhtml();
         $url = $Renderer->externalmedia($file,null,null,null,null,'cache','details',true);
 
-        $video = '<video class="media" width="320" height="240" controls="controls" poster="/tmp/lib/exe/fetch.php?media=wiki:kind_zu_katze.png">';
-        $this->assertEquals($video, substr($url,0,127));
+        $video = '<video class="media" width="320" height="240" controls="controls" poster="' . DOKU_BASE . 'lib/exe/fetch.php?media=wiki:kind_zu_katze.png">';
+        $substr_start = 0;
+        $substr_len = strlen($video);
+        $this->assertEquals($video, substr($url, $substr_start, $substr_len));
 
-        $source_webm = '<source src="/tmp/lib/exe/fetch.php?media=wiki:kind_zu_katze.webm" type="video/webm" />';
-        $this->assertEquals($source_webm, substr($url,128,87));
-        $source_ogv = '<source src="/tmp/lib/exe/fetch.php?media=wiki:kind_zu_katze.ogv" type="video/ogg" />';
-        $this->assertEquals($source_ogv, substr($url,216,85));
+        // find $source_webm in $url
+        $source_webm = '<source src="' . DOKU_BASE . 'lib/exe/fetch.php?media=wiki:kind_zu_katze.webm" type="video/webm" />';
+        $substr_start = strpos($url, $source_webm, $substr_start + $substr_len);
+        $this->assertNotSame(false, $substr_start, 'Substring not found.');
 
-        $a_webm = '<a href="/tmp/lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.webm" class="media mediafile mf_webm" title="wiki:kind_zu_katze.webm (99.1 KB)">kind_zu_katze.webm</a>';
-        $a_ogv = '<a href="/tmp/lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.ogv" class="media mediafile mf_ogv" title="wiki:kind_zu_katze.ogv (44.8 KB)">kind_zu_katze.ogv</a>';
-        $this->assertEquals($a_webm, substr($url,302,178));
-        $this->assertEquals($a_ogv, substr($url,480,174));
+        // find $source_ogv in $url
+        $source_ogv = '<source src="' . DOKU_BASE . 'lib/exe/fetch.php?media=wiki:kind_zu_katze.ogv" type="video/ogg" />';
+        $substr_start = strpos($url, $source_ogv, $substr_start + strlen($source_webm));
+        $this->assertNotSame(false, $substr_start, 'Substring not found.');
+
+        // find $a_webm in $url
+        $a_webm = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.webm" class="media mediafile mf_webm" title="wiki:kind_zu_katze.webm (99.1 KB)">kind_zu_katze.webm</a>';
+        $substr_start = strpos($url, $a_webm, $substr_start + strlen($source_ogv));
+        $this->assertNotSame(false, $substr_start, 'Substring not found.');
+
+        // find $a_webm in $url
+        $a_ogv = '<a href="' . DOKU_BASE . 'lib/exe/fetch.php?id=&amp;cache=&amp;media=wiki:kind_zu_katze.ogv" class="media mediafile mf_ogv" title="wiki:kind_zu_katze.ogv (44.8 KB)">kind_zu_katze.ogv</a>';
+        $substr_start = strpos($url, $a_ogv, $substr_start + strlen($a_webm));
+        $this->assertNotSame(false, $substr_start, 'Substring not found.');
 
         $rest = '</video>'."\n";
-        $this->assertEquals($rest, substr($url,654));
+        $substr_start = strlen($url) - strlen($rest);
+        $this->assertEquals($rest, substr($url, $substr_start));
     }
 }


### PR DESCRIPTION
These tests were passing on travis-ci but failing when run locally because the
tests are run from the /tmp directory on travis-ci but not when run locally.
