### PR TITLE
Fix Links in Recent Langauges list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_script:
 script:
   - cd _test
   - phpunit --verbose --stderr
-  - ../node_modules/karma/bin/karma start --browsers PhantomJS
+  - ../node_modules/karma/bin/karma start --single-run --browsers PhantomJS

--- a/_test/karma.conf.js
+++ b/_test/karma.conf.js
@@ -19,9 +19,11 @@ module.exports = function (config) {
             'lib/scripts/jquery/jquery-ui.js',
             'lib/scripts/jquery/jquery.cookie.js',
             'lib/scripts/jquery/jquery-migrate.js',
-            '_test/jasmine-jquery.js',
             'lib/scripts/tree.js',
             'lib/scripts/*.js',
+
+            // file needed for jasmine fixtures
+            '_test/jasmine-jquery.js',
 
             // served fixtures
             { pattern: 'lib/plugins/**/_test/fixtures/**/*.html', included: false, served: true },
@@ -29,6 +31,10 @@ module.exports = function (config) {
             // served script files
             { pattern: 'lib/plugins/**/*.js', included: false, served: true },
 
+            // files to include
+            'lib/plugins/door43translation/script.js',
+
+            // tests to run
             'lib/plugins/**/_test/*.test.js'
         ],
         // test results reporter to use
@@ -63,6 +69,6 @@ module.exports = function (config) {
 
         // Continuous Integration mode
         // if true, it capture browsers, run tests and exit
-        singleRun: true
+        singleRun: false
     });
 };

--- a/lib/plugins/door43translation/_test/fixtures/recent_languages_fixture.html
+++ b/lib/plugins/door43translation/_test/fixtures/recent_languages_fixture.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<!-- Test fixture of auto-complete language selector -->
+<head>
+    <!--suppress HtmlUnknownTarget -->
+    <script src="/base/lib/plugins/door43translation/private/js/auto_complete_events.js"></script>
+</head>
+<body>
+<div>
+    <input type="hidden" id="namespace-auto-complete-action" value="">
+    <input type="hidden" id="door43CurrentLanguage" value="">
+    <ul id="door43RecentLanguageList">
+    </ul>
+</div>
+</body>

--- a/lib/plugins/door43translation/_test/recent_languages.test.js
+++ b/lib/plugins/door43translation/_test/recent_languages.test.js
@@ -1,0 +1,112 @@
+
+describe("recent languages plugin tests", function() {
+    jasmine.getFixtures().fixturesPath = 'base';
+
+    beforeEach(function() {
+
+        // load language strings
+        LANG.plugins['door43translation'] = {selectLanguage: 'Select a language'};
+
+        // reset the cookie
+        Door43Cookie.setValue('recentNamespaceCodes', '');
+    });
+
+    it("recent languages list test", function() {
+
+        loadFixtures('lib/plugins/door43translation/_test/fixtures/recent_languages_fixture.html');
+
+        // verify the fixture loaded successfully
+        expect(jQuery('#jasmine-fixtures')).toBeTruthy();
+        var $hidden = jQuery('#door43CurrentLanguage');
+        expect($hidden).toBeTruthy();
+
+        // set the current language and action
+        $hidden.val('jbb:Jibberish');
+        document.getElementById('namespace-auto-complete-action').value = 'jbb:obs:01';
+        expect(document.getElementById('door43CurrentLanguage').value).toEqual('jbb:Jibberish');
+
+        // set the cookie - list of languages
+        saveNamespace('en', 'English');
+        saveNamespace('fr', 'French');
+        saveNamespace('es', 'Spanish');
+        saveNamespace('jbb', 'Jibberish');
+        expect(Door43Cookie.getValue('recentNamespaceCodes')).toEqual('en:English;fr:French;es:Spanish;jbb:Jibberish');
+
+        // run the code to build the list
+        buildRecentLanguagesList();
+
+        // verify the list
+        var $items = jQuery('#door43RecentLanguageList').find('li');
+        expect($items.length).toEqual(4);
+        expect(jQuery($items[0]).find('a').attr('href')).toEqual('/jbb/obs/01');
+        expect(jQuery($items[1]).find('a').attr('href')).toEqual('/es/obs/01');
+        expect(jQuery($items[2]).find('a').attr('href')).toEqual('/fr/obs/01');
+        expect(jQuery($items[3]).find('a').attr('href')).toEqual('/en/obs/01');
+    });
+
+    it("recent languages no namespace test", function() {
+
+        loadFixtures('lib/plugins/door43translation/_test/fixtures/recent_languages_fixture.html');
+
+        // verify the fixture loaded successfully
+        expect(jQuery('#jasmine-fixtures')).toBeTruthy();
+        var $hidden = jQuery('#door43CurrentLanguage');
+        expect($hidden).toBeTruthy();
+
+        // set the current language and action
+        $hidden.val('');
+        document.getElementById('namespace-auto-complete-action').value = 'home';
+        expect(document.getElementById('door43CurrentLanguage').value).toEqual('');
+
+        // set the cookie - list of languages
+        saveNamespace('en', 'English');
+        saveNamespace('fr', 'French');
+        saveNamespace('es', 'Spanish');
+        saveNamespace('jbb', 'Jibberish');
+        expect(Door43Cookie.getValue('recentNamespaceCodes')).toEqual('en:English;fr:French;es:Spanish;jbb:Jibberish');
+
+        // run the code to build the list
+        buildRecentLanguagesList();
+
+        // verify the list
+        var $items = jQuery('#door43RecentLanguageList').find('li');
+        expect($items.length).toEqual(4);
+        expect(jQuery($items[0]).find('a').attr('href')).toEqual('/jbb/home');
+        expect(jQuery($items[1]).find('a').attr('href')).toEqual('/es/home');
+        expect(jQuery($items[2]).find('a').attr('href')).toEqual('/fr/home');
+        expect(jQuery($items[3]).find('a').attr('href')).toEqual('/en/home');
+    });
+
+    it("recent languages no namespace longer action test", function() {
+
+        loadFixtures('lib/plugins/door43translation/_test/fixtures/recent_languages_fixture.html');
+
+        // verify the fixture loaded successfully
+        expect(jQuery('#jasmine-fixtures')).toBeTruthy();
+        var $hidden = jQuery('#door43CurrentLanguage');
+        expect($hidden).toBeTruthy();
+
+        // set the current language and action
+        $hidden.val('');
+        document.getElementById('namespace-auto-complete-action').value = 'asdfg:home:01';
+        expect(document.getElementById('door43CurrentLanguage').value).toEqual('');
+
+        // set the cookie - list of languages
+        saveNamespace('en', 'English');
+        saveNamespace('fr', 'French');
+        saveNamespace('es', 'Spanish');
+        saveNamespace('jbb', 'Jibberish');
+        expect(Door43Cookie.getValue('recentNamespaceCodes')).toEqual('en:English;fr:French;es:Spanish;jbb:Jibberish');
+
+        // run the code to build the list
+        buildRecentLanguagesList();
+
+        // verify the list
+        var $items = jQuery('#door43RecentLanguageList').find('li');
+        expect($items.length).toEqual(4);
+        expect(jQuery($items[0]).find('a').attr('href')).toEqual('/jbb/asdfg/home/01');
+        expect(jQuery($items[1]).find('a').attr('href')).toEqual('/es/asdfg/home/01');
+        expect(jQuery($items[2]).find('a').attr('href')).toEqual('/fr/asdfg/home/01');
+        expect(jQuery($items[3]).find('a').attr('href')).toEqual('/en/asdfg/home/01');
+    });
+});

--- a/lib/plugins/door43translation/helper.php
+++ b/lib/plugins/door43translation/helper.php
@@ -17,14 +17,14 @@ if (!defined('DS')) define('DS', DIRECTORY_SEPARATOR);
  */
 class helper_plugin_door43translation extends helper_plugin_translation {
 
-    var $LN = array(); // hold native names
-
     /**
      * Class constructor
      */
     function __construct() {
-
         parent::helper_plugin_translation();
+
+        // load language names
+        $this->LN = confToHash(dirname(__FILE__) . '/lang/langnames.txt');
     }
 
     /**

--- a/lib/plugins/door43translation/lang/langnames.txt
+++ b/lib/plugins/door43translation/lang/langnames.txt
@@ -78,7 +78,6 @@ adj	Adioukrou
 adl	Galo
 adn	Adang
 ado	Abu
-adp	Adap
 adq	Adangbe
 adr	Adonara
 ads	Adamorobe Sign Language
@@ -91,7 +90,7 @@ adz	Adzera
 aeb	Tunisian Arabic
 aec	Saidi Arabic
 aed	Argentine Sign Language
-aee	Northeast Pashayi
+aee	Northeast Pashai
 aek	Haeke
 ael	Ambele
 aem	Arem
@@ -293,7 +292,7 @@ aol	Alor
 aom	Ömie
 aon	Bumbita Arapesh
 aos	Taikat
-aot	A'tong
+aot	Atong
 aou	A'ou
 aox	Atorada
 aoz	Uab Meto
@@ -331,7 +330,7 @@ aqr	Arhâ
 aqt	Angaité
 aqz	Akuntsu
 ar	العربية
-ar-x-dcv	Arabic Dominant Culture Variant
+ar-x-dcv	العربية Dominant Culture Variant
 arb	Standard Arabic
 arc	Official Aramaic (700-300 BCE)
 ard	Arabana
@@ -406,7 +405,6 @@ aua	Asumboa
 aub	Alugu
 auc	Waorani
 aud	Anuta
-aue	=/Kx'au//'ein
 aug	Aguna
 auh	Aushi
 aui	Anuki
@@ -802,7 +800,6 @@ bmu	Somba-Siawari
 bmv	Bum
 bmw	Bomwali
 bmx	Baimak
-bmy	Bemba (Democratic Republic of Congo)
 bmz	Baramu
 bn	বাংলা
 bna	Bonerate
@@ -1061,7 +1058,6 @@ bxr	Russia Buriat
 bxs	Busam
 bxu	China Buriat
 bxw	Bankagooma
-bxx	Borna (Democratic Republic of Congo)
 bxz	Binahari
 bya	Batak
 byc	Ubaghara
@@ -1082,7 +1078,6 @@ bys	Burak
 byv	Medumba
 byw	Belhariya
 byx	Qaqet
-byy	Buya
 byz	Banaro
 bza	Bandi
 bzb	Andio
@@ -1110,7 +1105,7 @@ bzw	Basa (Nigeria)
 bzx	Kɛlɛngaxo Bozo
 bzy	Obanliku
 bzz	Evant
-ca	català, valencià
+ca	català
 caa	Chortí
 cab	Garifuna
 cac	Chuj
@@ -1143,6 +1138,7 @@ cbk	Chavacano
 cbl	Bualkhaw Chin
 cbn	Nyahkur
 cbo	Izora
+cbq	Tsucuba
 cbr	Cashibo-Cacataibo
 cbs	Cashinahua
 cbt	Chayahuita
@@ -1687,7 +1683,6 @@ dyu	Dyula
 dyy	Dyaabugay
 dz	རྫོང་ཁ
 dza	Tunzu
-dzd	Daza
 dzg	Dazaga
 dzl	Dzalakha
 dzn	Dzando
@@ -1728,6 +1723,7 @@ eky	Eastern Kayah
 el	ελληνικά
 ele	Elepi
 elh	El Hugeirat
+eli	Nding
 elk	Elkei
 elm	Eleme
 elo	El Molo
@@ -1776,7 +1772,7 @@ ero	Horpa
 ers	Ersu
 ert	Eritai
 erw	Erokwanas
-es	español, castellano
+es	español
 es-419	Español Latin America
 ese	Ese Ejja
 esh	Eshtehardi
@@ -1872,6 +1868,7 @@ fqs	Fas
 fr	français
 frc	Cajun French
 frd	Fordata
+frk	Frankish
 frm	Middle French (ca. 1400-1600)
 fro	Old French (842-ca. 1400)
 frp	Arpitan
@@ -2003,7 +2000,6 @@ gey	Enya
 gez	Geez
 gfk	Patpatar
 gft	Gafat
-gfx	Mangetti Dune !Xung
 gga	Gao
 ggb	Gbii
 gge	Guragone
@@ -2055,7 +2051,7 @@ gkp	Guinea Kpelle
 gl	galego
 glc	Bon Gula
 gld	Nanai
-glh	Northwest Pashayi
+glh	Northwest Pashai
 glj	Gula Iro
 glk	Gilaki
 glo	Galambu
@@ -2156,7 +2152,6 @@ gsp	Wasembo
 gss	Greek Sign Language
 gsw	Swiss German
 gta	Guató
-gti	Gbati-ri
 gu	ગુજરાતી
 gua	Shiki
 gub	Guajajára
@@ -2471,6 +2466,7 @@ ikk	Ika
 ikl	Ikulu
 iko	Olulumo-Ikom
 ikp	Ikpeshi
+iks	Inuit Sign Language
 ikt	Inuinnaqtun
 ikv	Iku-Gora-Ankwa
 ikw	Ikwere
@@ -2486,7 +2482,6 @@ ils	International Sign
 ilu	Ili'uun
 ilv	Ilue
 ima	Mala Malasar
-ime	Imeraguen
 imi	Anamgura
 iml	Miluk
 imn	Imonda
@@ -2636,6 +2631,7 @@ jit	Jita
 jiu	Youle Jinuo
 jiv	Shuar
 jiy	Buyuan Jinuo
+jje	Jejueo
 jjr	Bankal
 jkm	Mobwa Karen
 jko	Kubo
@@ -2722,7 +2718,6 @@ kbb	Kaxuiâna
 kbc	Kadiwéu
 kbd	Kabardian
 kbe	Kanju
-kbf	Kakauhua
 kbg	Khamba
 kbh	Camsá
 kbi	Kaptiau
@@ -2935,6 +2930,7 @@ kjr	Kurudu
 kjs	East Kewa
 kjt	Phrae Pwo Karen
 kju	Kashaya
+kjv	Kaikavian Literary Language
 kjx	Ramopa
 kjy	Erave
 kjz	Bumthangkha
@@ -3053,7 +3049,6 @@ kof	Kubi
 kog	Cogui
 koh	Koyo
 koi	Komi-Permyak
-koj	Sara Dunjo
 kok	Konkani (macrolanguage)
 kol	Kol (Papua New Guinea)
 koo	Konzo
@@ -3193,7 +3188,7 @@ ku	Kurdî, كوردی‎
 kub	Kutep
 kuc	Kwinsu
 kud	'Auhelawa
-kue	Kuman
+kue	Kuman (Papua New Guinea)
 kuf	Western Katu
 kug	Kupa
 kuh	Kushi
@@ -3258,7 +3253,6 @@ kwm	Kwambi
 kwn	Kwangali
 kwo	Kwomtari
 kwp	Kodia
-kwq	Kwak
 kwr	Kwer
 kws	Kwese
 kwt	Kwesten
@@ -3271,7 +3265,6 @@ kxa	Kairiru
 kxb	Krobu
 kxc	Konso
 kxd	Brunei
-kxe	Kakihum
 kxf	Manumanaw Karen
 kxh	Karo (Ethiopia)
 kxi	Keningau Murut
@@ -3471,7 +3464,6 @@ lie	Likila
 lif	Limbu
 lig	Ligbi
 lih	Lihir
-lii	Lingkhim
 lij	Ligurian
 lik	Lika
 lil	Lillooet
@@ -4210,7 +4202,6 @@ mwf	Murrinh-Patha
 mwg	Aiklep
 mwh	Mouk-Aria
 mwi	Labo
-mwj	Maligo
 mwk	Kita Maninkakan
 mwl	Mirandese
 mwm	Sar
@@ -4312,10 +4303,10 @@ nam	Ngan'gityemerri
 nan	Min Nan Chinese
 nao	Naaba
 nap	Neapolitan
-naq	Nama (Namibia)
+naq	Khoekhoe
 nar	Iguta
 nas	Naasioi
-nat	Hungworo
+nat	Ca̱hungwa̱rya̱
 naw	Nawuri
 nax	Nakwi
 nay	Narrinyeri
@@ -4446,6 +4437,7 @@ ngy	Tibea
 ngz	Ngungwel
 nha	Nhanda
 nhb	Beng
+nhc	Tabasco Nahuatl
 nhd	Chiripá
 nhe	Eastern Huasteca Nahuatl
 nhf	Nhuwala
@@ -4637,6 +4629,7 @@ nra	Ngom
 nrb	Nara
 nrc	Noric
 nre	Southern Rengma Naga
+nrf	Jèrriais
 nrg	Narango
 nri	Chokri Naga
 nrk	Ngarla
@@ -4708,7 +4701,7 @@ nuw	Nguluwan
 nux	Mehek
 nuy	Nunggubuyu
 nuz	Tlamacazapa Nahuatl
-nv	Diné bizaad, Dinékʼehǰí
+nv	Diné bizaad
 nvh	Nasarian
 nvm	Namiae
 nvo	Nyokon
@@ -4729,6 +4722,7 @@ nxi	Nindi
 nxk	Koki Naga
 nxl	South Nuaulu
 nxm	Numidian
+nxo	Ndambomo
 nxq	Naxi
 nxr	Ninggerum
 nxu	Narau
@@ -4916,7 +4910,6 @@ oua	Tagargrent
 oub	Glio-Oubi
 oue	Oune
 oui	Old Uighur
-oun	!O!ung
 owi	Owiniga
 owl	Old Welsh
 oyb	Oy
@@ -4964,7 +4957,7 @@ pbs	Central Pame
 pbt	Southern Pashto
 pbu	Northern Pashto
 pbv	Pnar
-pby	Pyu
+pby	Pyu (Papua New Guinea)
 pca	Santa Inés Ahuatempan Popoloca
 pcb	Pear
 pcc	Bouyei
@@ -5011,6 +5004,7 @@ pfa	Pááfang
 pfe	Peere
 pfl	Pfaelzisch
 pga	Sudanese Creole Arabic
+pgd	Gāndhārī
 pgg	Pangwali
 pgi	Pagi
 pgk	Rerep
@@ -5084,7 +5078,7 @@ pln	Palenquero
 plo	Oluta Popoluca
 plq	Palaic
 plr	Palaka Senoufo
-pls	San Marcos Tlalcoyalco Popoloca
+pls	San Marcos Tlacoyalco Popoloca
 plt	Plateau Malagasy
 plu	Palikúr
 plv	Southwest Palawano
@@ -5106,7 +5100,6 @@ pmq	Northern Pame
 pmr	Paynamar
 pms	Piemontese
 pmt	Tuamotuan
-pmu	Mirpur Panjabi
 pmw	Plains Miwok
 pmx	Poumei Naga
 pmy	Papuan Malay
@@ -5139,6 +5132,7 @@ pog	Potiguára
 poh	Poqomchi'
 poi	Highland Popoluca
 pok	Pokangá
+pom	Southeastern Pomo
 pon	Pohnpeian
 poo	Central Pomo
 pop	Pwapwâ
@@ -5191,8 +5185,8 @@ psc	Persian Sign Language
 psd	Plains Indian Sign Language
 pse	Central Malay
 psg	Penang Sign Language
-psh	Southwest Pashayi
-psi	Southeast Pashayi
+psh	Southwest Pashai
+psi	Southeast Pashai
 psl	Puerto Rican Sign Language
 psm	Pauserna
 psn	Panasuan
@@ -5294,6 +5288,7 @@ qvw	Huaylla Wanca Quechua
 qvy	Queyu
 qvz	Northern Pastaza Quichua
 qwa	Corongo Ancash Quechua
+qwc	Classical Quechua
 qwh	Huaylas Ancash Quechua
 qwm	Kuman (Russia)
 qws	Sihuas Ancash Quechua
@@ -5437,8 +5432,9 @@ rsl	Russian Sign Language
 rtc	Rungtu Chin
 rth	Ratahan
 rtm	Rotuman
+rts	Yurats
 rtw	Rathawi
-ru	русский язык
+ru	Русский
 rub	Gungu
 ruc	Ruuli
 rue	Rusyn
@@ -5491,7 +5487,7 @@ sbb	Simbo
 sbc	Kele (Papua New Guinea)
 sbd	Southern Samo
 sbe	Saliba
-sbf	Shabo
+sbf	Chabu
 sbg	Seget
 sbh	Sori-Harengan
 sbi	Seti
@@ -5589,7 +5585,6 @@ sgh	Shughni
 sgi	Suga
 sgj	Surgujia
 sgk	Sangkong
-sgo	Songa
 sgp	Singpho
 sgr	Sangisari
 sgs	Samogitian
@@ -5664,7 +5659,7 @@ sjs	Senhaja De Srair
 sjt	Ter Sami
 sju	Ume Sami
 sjw	Shawnee
-sk	slovenčina, slovenský jazyk
+sk	सराइकी,سرائیکی, ਸਰਾਇਕੀ‎
 ska	Skagit
 skb	Saek
 skc	Ma Manda
@@ -5681,7 +5676,7 @@ skn	Kolibugan Subanon
 sko	Seko Tengah
 skp	Sekapan
 skq	Sininkere
-skr	Seraiki
+skr	सराइकी,سرائیکی, ਸਰਾਇਕੀ‎
 sks	Maia
 skt	Sakata
 sku	Sakao
@@ -5901,7 +5896,7 @@ suw	Sumbwa
 sux	Sumerian
 suy	Suyá
 suz	Sunwar
-sv	Svenska
+sv	svenska
 sva	Svan
 svb	Ulau-Suain
 svc	Vincentian Creole English
@@ -5958,6 +5953,7 @@ syo	Suoy
 syr	Syriac
 sys	Sinyar
 syw	Kagate
+syx	Samay
 syy	Al-Sayyid Bedouin Sign Language
 sza	Semelai
 szb	Ngalum
@@ -6085,7 +6081,7 @@ tfn	Tanaina
 tfo	Tefaro
 tfr	Teribe
 tft	Ternate
-tg	тоҷикӣ, toğikī, تاجیکی‎
+tg	тоҷикӣ, toçikī, تاجیکی‎
 tga	Sagalla
 tgb	Tobilung
 tgc	Tigak
@@ -6126,7 +6122,6 @@ tht	Tahltan
 thu	Thuri
 thv	Tahaggart Tamahaq
 thw	Thudam
-thx	The
 thy	Tha
 thz	Tayart Tamajeq
 ti	ትግርኛ
@@ -6337,7 +6332,6 @@ tsb	Tsamai
 tsc	Tswa
 tsd	Tsakonian
 tse	Tunisian Sign Language
-tsf	Southwestern Tamang
 tsg	Tausug
 tsh	Tsuvan
 tsi	Tsimshian
@@ -6442,6 +6436,7 @@ txe	Totoli
 txg	Tangut
 txh	Thracian
 txi	Ikpeng
+txj	Tarjumo
 txm	Tomini
 txn	West Tarangan
 txo	Toto
@@ -6493,7 +6488,7 @@ udm	Udmurt
 udu	Uduk
 ues	Kioko
 ufi	Ufim
-ug	Uyƣurqə, ئۇيغۇرچە‎
+ug	ئۇيغۇرچە‎, Uyghurche
 uga	Ugaritic
 uge	Ughele
 ugn	Ugandan Sign Language
@@ -6547,7 +6542,6 @@ unr	Mundari
 unu	Unubahe
 unx	Munda
 unz	Unde Kaili
-uok	Uokha
 upi	Umeda
 upv	Uripiv-Wala-Rano-Atchin
 ur	اردو
@@ -6588,7 +6582,7 @@ uvh	Uri
 uvl	Lote
 uwa	Kuku-Uwanh
 uya	Doko-Uyanga
-uz	O‘zbek, Ўзбек, أۇزبېك‎
+uz	Oʻzbek, Ўзбек, أۇزبېك‎
 uzn	Northern Uzbek
 uzs	Southern Uzbek
 vaa	Vaagri Booli
@@ -6597,7 +6591,7 @@ vaf	Vafsi
 vag	Vagla
 vah	Varhadi-Nagpuri
 vai	Vai
-vaj	Vasekela Bushman
+vaj	Sekele
 val	Vehes
 vam	Vanimo
 van	Valman
@@ -6620,7 +6614,7 @@ vep	Veps
 ver	Mom Jango
 vgr	Vaghri
 vgt	Vlaamse Gebarentaal
-vi	Tiếng Việt
+vi	Việtnam
 vic	Virgin Islands Creole English
 vid	Vidunda
 vif	Vili
@@ -7055,7 +7049,6 @@ xsd	Sidetic
 xse	Sempan
 xsh	Shamang
 xsi	Sio
-xsj	Subi
 xsl	South Slavey
 xsm	Kasem
 xsn	Sanga (Nigeria)
@@ -7170,7 +7163,6 @@ ydd	Eastern Yiddish
 yde	Yangum Dey
 ydg	Yidgha
 ydk	Yoidik
-yds	Yiddish Sign Language
 yea	Ravula
 yec	Yeniche
 yee	Yimas
@@ -7249,13 +7241,11 @@ ymp	Yamap
 ymq	Qila Muji
 ymr	Malasar
 yms	Mysian
-ymt	Mator-Taygi-Karagas
 ymx	Northern Muji
 ymz	Muzi
 yna	Aluo
 yne	Lang'e
 yng	Yango
-ynh	Yangho
 ynk	Naukan Yupik
 ynl	Yangulam
 ynn	Yana

--- a/lib/plugins/door43translation/private/js/auto_complete_events.js
+++ b/lib/plugins/door43translation/private/js/auto_complete_events.js
@@ -45,7 +45,7 @@ function translationSelectNamespace(langIso, langText) {
     // if the namespace didn't change, do nothing
     if (NS && (langIso === NS)) return;
 
-    saveNamespace(langIso, langText)
+    saveNamespace(langIso, langText);
 
     var action = jQuery('#namespace-auto-complete-action').val();
     var pos = action.indexOf(':');

--- a/lib/plugins/door43translation/script.js
+++ b/lib/plugins/door43translation/script.js
@@ -86,30 +86,7 @@ function saveNamespace(langIso, langText) {
     }
 }
 
-/**
- * Remove go button from translation dropdown
- */
-jQuery(function(){
-    var $frm = jQuery('#translation__dropdown');
-    if(!$frm.length) return;
-
-    var dropdown = $frm.find('select[name=id]');
-    if (!dropdown.length) return;
-
-    $frm.find('input[name=go]').hide();
-    dropdown.change(function() {
-
-        var id = jQuery(this).val();
-
-        // this should hopefully detect rewriting good enough:
-        var action = $frm.attr('action');
-
-        window.location.href = (action.substr(action.length - 1) == '/')
-            ? action + id : action + '?id=' + id;
-    });
-});
-
-jQuery().ready(function() {
+function buildRecentLanguagesList() {
 
     // get the url for language links
     var action = jQuery('#namespace-auto-complete-action').val();
@@ -158,7 +135,7 @@ jQuery().ready(function() {
             }
         }
 
-        action = action.replace(':', '/');
+        action = action.replace(/:/g, '/');
 
         // get the list of recent languages
         var ul = jQuery('#door43RecentLanguageList');
@@ -167,8 +144,34 @@ jQuery().ready(function() {
             // format = code:language description
             var values = cookies[j].split(':');
 
-            ul.append('<li style="float: none;"><a href="' + DOKU_BASE + values[0] + '/' + action + '">' + values[1] + '</a></li>');
+            ul.append('<li style="float: none;"><a href="' + DOKU_BASE + values[0] + '/' + action + '"><span lang="' + values[0] + '">' + values[1] + '</span></a></li>');
         }
     }
     jQuery('#namespace-auto-complete').val(nsDescription);
+}
+/**
+ * Remove go button from translation dropdown
+ */
+jQuery(function(){
+    var $frm = jQuery('#translation__dropdown');
+    if(!$frm.length) return;
+
+    var dropdown = $frm.find('select[name=id]');
+    if (!dropdown.length) return;
+
+    $frm.find('input[name=go]').hide();
+    dropdown.change(function() {
+
+        var id = jQuery(this).val();
+
+        // this should hopefully detect rewriting good enough:
+        var action = $frm.attr('action');
+
+        window.location.href = (action.substr(action.length - 1) == '/')
+            ? action + id : action + '?id=' + id;
+    });
+});
+
+jQuery().ready(function() {
+    buildRecentLanguagesList();
 });


### PR DESCRIPTION
There were 2 problems:
1. The list of possible namespaces was using the Dokuwiki default list which only contains 185 languages.
2. The javascript that creates the href url was not replacing all colons. The string.replace() function by default only replaces the first occurence.
