### PR TITLE
Update Door43 to use Noto Sans rather than Lato

### DIFF
--- a/conf/userstyle.css
+++ b/conf/userstyle.css
@@ -1,11 +1,10 @@
-@import url(http://fonts.googleapis.com/css?family=Noto%20Sans:400,700,400italic);
 
 /*
  * TEXT
  */
 
-body, p { font-family: 'Noto Sans', sans-serif; font-weight: 400; }
-h1, h2, h3, h4 { font-family: 'Noto Sans', sans-serif; font-weight: 700; }
+body, p { font-weight: 400; }
+h1, h2, h3, h4 { font-weight: 700; }
 
 .dokuwiki .docInfo { color: #aaa; }
 
@@ -13,6 +12,6 @@ h1, h2, h3, h4 { font-family: 'Noto Sans', sans-serif; font-weight: 700; }
  * IMAGES
  */
 
-.dokuwiki img.media { margin-top: .8em; margin-bottom: 0em;}
+.dokuwiki img.media { margin-top: .8em; margin-bottom: 0;}
 
 img.download { opacity: 0.5; }

--- a/lib/tpl/door43/css/fonts.css
+++ b/lib/tpl/door43/css/fonts.css
@@ -29,5 +29,5 @@
 :lang(ti),
 :lang(tir),
 :lang(tig) {
-  font-family: 'Noto Sans Ethiopic', inherit, sans-serif;
+  font-family: 'Noto Sans Ethiopic', 'Noto Sans', sans-serif;
 }


### PR DESCRIPTION
The first attempt appears to only work in Firefox

Resolves  #120.
