### PR TITLE
Upload OBS docx file step 2

### DIFF
--- a/lib/plugins/door43obsdocupload/lang/en/lang.php
+++ b/lib/plugins/door43obsdocupload/lang/en/lang.php
@@ -25,6 +25,7 @@ $lang['docxImportSucceeded'] = 'Import of OBS from DOCX completed successfully. 
 $lang['loginRequired'] = 'You must be logged in before you can upload a file.';
 $lang['uploadProgress'] = 'Upload progress';
 $lang['uploadProcessing'] = 'Processing the uploaded file';
+$lang['publishSucceeded'] = 'OBS has been published successfully.';
 
 // error messages
 $lang['docxFileCreateError'] = 'Error creating the docx file';
@@ -33,7 +34,10 @@ $lang['fileTypeNotSupported'] = 'Only .docx and .zip files are supported.';
 $lang['zipNoDocxFiles'] = 'No .docx files were found in the zip file.';
 $lang['zipMultipleDocxFiles'] = 'More than one .docx file was found in the zip file.';
 $lang['pandocError'] = 'An error occurred converting the file to Dokuwiki format:';
-$lang['obsNotInitialized'] = 'Open Bible Stories has not been initialized for %1$s. <a href="/obs-setup">Click here to go to the initialization page.</a>';
+$lang['obsNotInitialized'] = 'Open Bible Stories has not been initialized for %1$s. <a href="%2$s">Click here to go to the initialization page.</a>';
+$lang['previewNotFound'] = 'The preview directory was not found.';
+$lang['notAbleToCopy'] = 'Door43 was not able to copy %1$s.';
+$lang['sourceFileNotFound'] = 'Source file not found: %1$s';
 
 // localized strings for JavaScript
 // js example: var text = LANG.plugins['door43register']['translate'];

--- a/lib/plugins/door43obsdocupload/obs-upload.js
+++ b/lib/plugins/door43obsdocupload/obs-upload.js
@@ -90,5 +90,49 @@ function showObsUploadProgress(e) {
 }
 
 function publishUploadedOBS() {
-    alert('todo: Publish is not yet implemented');
+
+    disable_page();
+
+    var url = DOKU_BASE + 'lib/exe/ajax.php';
+    var langCode = document.getElementById('selectDocxNamespace').value;
+
+    var dataValues = {
+        call: 'publish_obs_docx',
+        lang: langCode
+    };
+
+    var ajaxSettings = {
+        type: 'POST',
+        url: url,
+        data: dataValues
+    };
+
+    jQuery.ajax(ajaxSettings).done(function(data) {
+
+        var msg;
+        var $result = jQuery('#obsDocxPublishMessage');
+
+        if (typeof data === 'string') {
+
+            // most likely an error has occurred
+            msg = data;
+            $result.attr('class', 'failure');
+        }
+        else {
+
+            // the ajax call succeeded, display the results
+            msg = data['htmlMessage'];
+            if (data['result'] === 'OK') {
+
+                // the uploaded stories are published
+                $result.attr('class', 'success');
+            }
+            else {
+                $result.attr('class', 'failure');
+            }
+        }
+
+        $result.html(msg).show();
+        enable_page();
+    });
 }

--- a/lib/plugins/door43obsdocupload/templates/obs_import.php
+++ b/lib/plugins/door43obsdocupload/templates/obs_import.php
@@ -41,7 +41,7 @@ if ($translation) echo $translation->renderAutoCompleteTextBox('selectDocxNamesp
         </div>
         <div id="publishDiv" style="display: none;">
             <button onclick="publishUploadedOBS();">@publishButton@</button>
-            <p id="obsDocxUploadMessage" class="success failure">&nbsp;</p>
+            <p id="obsDocxPublishMessage" class="success failure">&nbsp;</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This allows the user to upload a docx file or a zipped docx file and import it into the Door43 namespace. This first step creates a `obs-preview` directory that allows the user to verify the upload was successful. The second step publishes the uploaded stories.

Resolves #80
