### PR TITLE
Remove the uwadmin transclusion from OBS setup

### DIFF
--- a/lib/plugins/door43obs/action/PopulateOBS.php
+++ b/lib/plugins/door43obs/action/PopulateOBS.php
@@ -402,7 +402,7 @@ class action_plugin_door43obs_PopulateOBS extends DokuWiki_Action_Plugin {
         }
 
         $text = file_get_contents($sidebarFile);
-        $text .= "\n**Resources**\n\n  * [[{$dstLangCode}:obs|Open Bible Stories ({$dstLangCode})]]\n\n**Latest OBS Status**\n{{page>en:uwadmin:{$dstLangCode}:obs:status}}";
+        $text .= "\n**Resources**\n\n  * [[{$dstLangCode}:obs|Open Bible Stories ({$dstLangCode})]]";
         file_put_contents($sidebarFile, $text);
     }
 


### PR DESCRIPTION
Remove the portion of code in the OBS setup that links sidebar.txt to the en/uwadmin page for that language.

Resolves #229.
