### PR TITLE
Enable OBS template export for all pages

### DIFF
--- a/lib/plugins/door43obsdocupload/action/ExportButtons.php
+++ b/lib/plugins/door43obsdocupload/action/ExportButtons.php
@@ -26,12 +26,6 @@ class action_plugin_door43obsdocupload_ExportButtons extends Door43_Action_Plugi
 
     private $tempDir;
 
-    /**
-     * possible values: -1 = not set, 0 = false, 1 = true
-     * @var int
-     */
-    private $showButton = -1;
-
     public function __destruct() {
 
         // cleanup
@@ -61,34 +55,7 @@ class action_plugin_door43obsdocupload_ExportButtons extends Door43_Action_Plugi
         Door43_Ajax_Helper::register_handler($controller, 'get_obs_doc_export_dlg', array($this, 'get_obs_doc_export_dlg'));
         Door43_Ajax_Helper::register_handler($controller, 'download_obs_template_docx', array($this, 'download_obs_template_docx'));
     }
-
-    /**
-     * @return int
-     */
-    private function showToolstripButton() {
-
-        if ($this->showButton == -1) {
-
-            global $INFO;
-
-            $parts = explode(':', strtolower($INFO['id']));
-
-            // If this is an OBS request, the id will have these parts:
-            // [0] = language code / namespace
-            // [1] = 'obs'
-            // [2] = story number '01' - '50'
-            if (count($parts) < 2)
-                $this->showButton = 0;
-            elseif ($parts[1] !== 'obs')
-                $this->showButton = 0;
-            elseif (isset($parts[2]) && (preg_match('/^[0-9][0-9]$/', $parts[2]) !== 1))
-                $this->showButton = 0;
-            else
-                $this->showButton = 1;
-        }
-
-        return $this->showButton;
-    }
+    
 
     /**
      * This the script for the button in the right-hand tool strip on OBS pages.
@@ -99,8 +66,6 @@ class action_plugin_door43obsdocupload_ExportButtons extends Door43_Action_Plugi
     public function load_pagetools_script(Doku_Event &$event, /** @noinspection PhpUnusedParameterInspection */ $param) {
 
         if ($event->data !== 'show') return;
-
-        if ($this->showToolstripButton() !== 1) return;
 
         $html = file_get_contents(dirname(dirname(__FILE__)) . '/templates/obs_export_script.html');
 
@@ -113,8 +78,6 @@ class action_plugin_door43obsdocupload_ExportButtons extends Door43_Action_Plugi
      * @param Doku_Event $event
      */
     public function add_button(Doku_Event $event) {
-
-        if ($this->showToolstripButton() !== 1) return;
 
         // export button
         $btn = '<li id="getObsTemplateBtn"><a href="#" class=" tx-export" rel="nofollow" ><span>' . $this->getLang('getTemplate') . '</span></a></li>';

--- a/lib/plugins/door43obsdocupload/script.js
+++ b/lib/plugins/door43obsdocupload/script.js
@@ -66,57 +66,72 @@ function setupExportClick() {
 
     var btn = jQuery('#getObsTemplateBtn');
 
-    btn.on('click', function() {
+    btn.on('click', function(evt) {
+
+        evt.preventDefault();
 
         // if we don't remove focus, the button appears to be stuck
         jQuery(this).children().blur();
 
-        jQuery('#door43ObsExportDiv').dialog({
-            height: 360,
-            width: 500,
-            modal: true,
-            open: function() {
+        showObsExportDialog();
+    });
+}
 
-                if (!document.getElementById('door43ObsExportOptions').innerHTML) {
+function showObsExportDialog() {
 
+    jQuery('#door43ObsExportDiv').dialog({
+        height: 360,
+        width: 500,
+        modal: true,
+        open: function() {
+
+            if (!document.getElementById('door43ObsExportOptions').innerHTML) {
+
+                var url = DOKU_BASE + 'lib/exe/ajax.php';
+
+                var dataValues = {
+                    call: 'get_obs_doc_export_dlg'
+                };
+
+                var ajaxSettings = {
+                    type: 'GET',
+                    url: url,
+                    data: dataValues
+                };
+
+                jQuery.ajax(ajaxSettings).done(function(data) {
+                    document.getElementById('door43ObsExportOptions').innerHTML = data;
+
+                    // We need to get the data from the plugin because of browser Cross-Origin restrictions.
                     var url = DOKU_BASE + 'lib/exe/ajax.php';
 
                     var dataValues = {
-                        call: 'get_obs_doc_export_dlg'
+                        call: 'cross_origin_request',
+                        contentType: 'application/json',
+                        requestUrl: 'https://api.unfoldingword.org/obs/txt/1/obs-catalog.json'
                     };
 
                     var ajaxSettings = {
-                        type: 'GET',
+                        type: 'POST',
                         url: url,
                         data: dataValues
                     };
 
                     jQuery.ajax(ajaxSettings).done(function(data) {
-                        document.getElementById('door43ObsExportOptions').innerHTML = data;
+                        if (!data) return;
+                        availableLanguages = data;
 
-                        // We need to get the data from the plugin because of browser Cross-Origin restrictions.
-                        var url = DOKU_BASE + 'lib/exe/ajax.php';
+                        // disable draft option if not in a namespace
+                        if (!NS) {
+                            document.getElementById('useDraft').setAttribute('disabled', 'disabled');
+                            document.getElementById('useSource').setAttribute('checked', 'checked');
+                            enableDisableObsExportControls();
+                        }
 
-                        var dataValues = {
-                            call: 'cross_origin_request',
-                            contentType: 'application/json',
-                            requestUrl: 'https://api.unfoldingword.org/obs/txt/1/obs-catalog.json'
-                        };
-
-                        var ajaxSettings = {
-                            type: 'POST',
-                            url: url,
-                            data: dataValues
-                        };
-
-                        jQuery.ajax(ajaxSettings).done(function(data) {
-                            if (!data) return;
-                            availableLanguages = data;
-                            populateAvailableOBSLanguages(false);
-                        });
+                        populateAvailableOBSLanguages(false);
                     });
-                }
+                });
             }
-        });
+        }
     });
 }

--- a/lib/plugins/door43obsdocupload/templates/obs_export_script.html
+++ b/lib/plugins/door43obsdocupload/templates/obs_export_script.html
@@ -10,7 +10,6 @@
 <script type="text/javascript">
     jQuery().ready(function() {
         setupExportClick();
-        setupImportClick();
     });
 </script>
 <div id="door43ObsExportDiv" title="@exportTitle@" style="display: none">


### PR DESCRIPTION
Previously this option was only available if the user was on a OBS page.

Part one for issue #233.
