### PR TITLE
Fix 'Skipping git_push during testing' message on server

### DIFF
--- a/lib/plugins/door43obs/action/PopulateOBS.php
+++ b/lib/plugins/door43obs/action/PopulateOBS.php
@@ -436,7 +436,7 @@ class action_plugin_door43obs_PopulateOBS extends DokuWiki_Action_Plugin {
     private static function git_push($dir, $msg) {
 
         // skip this section during unit testing
-        if(!defined('DOKU_UNITTEST')) return 'Skipping git_push during testing<br>';
+        if(defined('DOKU_UNITTEST')) return 'Skipping git_push during testing<br>';
 
         // initialize the return value
         $returnVal = '';


### PR DESCRIPTION
The problem was a typo, fixed by changing `if(!defined('DOKU_UNITTEST'))` to `if(defined('DOKU_UNITTEST'))`.

Resolves #230.
