### PR TITLE
Clean up plugin.info.txt files

### DIFF
--- a/lib/plugins/door43obs/plugin.info.txt
+++ b/lib/plugins/door43obs/plugin.info.txt
@@ -2,6 +2,6 @@ base   door43obs
 author Phil Hopper
 email  phillip_hopper@wycliffeassociates.org
 date   2014-12-19
-name   door43obs plugin
+name   Door43 OBS Plugin
 desc   Open Bible Stories support
 url    https://github.com/Door43/dokuwiki-plugin-obs

--- a/lib/plugins/door43obsaudioupload/plugin.info.txt
+++ b/lib/plugins/door43obsaudioupload/plugin.info.txt
@@ -2,6 +2,6 @@ base   door43obsaudioupload
 author Phil Hopper
 email  phillip_hopper@wycliffeassociates.org
 date   2014-12-19
-name   Door43 OBS Audio Upload plugin
+name   Door43 OBS Audio Upload Plugin
 desc   Uploads audio files for Open Bible Stories
 url    https://github.com/unfoldingWord-dev/dokuwiki-plugin-obs-audio-upload

--- a/lib/plugins/door43obsdocupload/plugin.info.txt
+++ b/lib/plugins/door43obsdocupload/plugin.info.txt
@@ -1,7 +1,7 @@
 base   door43obsdocupload
 author Phil Hopper
-email  https://unfoldingword.org/contact/
+email  phillip_hopper@wycliffeassociates.org
 date   2015-05-20
-name   door43obsdocupload plugin
+name   Door43 OBS Doc Upload Plugin
 desc   Upload and parse documents containing OBS translations
 url    https://github.com/Door43/dokuwiki-plugin-obs-doc-upload

--- a/lib/plugins/door43obsreview/plugin.info.txt
+++ b/lib/plugins/door43obsreview/plugin.info.txt
@@ -1,7 +1,7 @@
 base   door43obsreview
 author Phil Hopper
-email  https://unfoldingword.org/contact/
+email  phillip_hopper@wycliffeassociates.org
 date   2015-04-06
-name   door43obsreview plugin
+name   Door43 OBS Review Plugin
 desc   Open Bible Stories support
 url    https://github.com/unfoldingWord-dev/dokuwiki-plugin-obs-review

--- a/lib/plugins/door43register/plugin.info.txt
+++ b/lib/plugins/door43register/plugin.info.txt
@@ -1,7 +1,7 @@
 base   door43register
 author Phil Hopper
-email  https://unfoldingword.org/contact/
+email  phillip_hopper@wycliffeassociates.org
 date   2014-12-19
-name   door43register plugin
+name   Door43 Register Plugin
 desc   Override the default register behavior
 url    https://github.com/Door43/dokuwiki-plugin-register

--- a/lib/plugins/door43shared/plugin.info.txt
+++ b/lib/plugins/door43shared/plugin.info.txt
@@ -1,7 +1,7 @@
 base   door43shared
 author Phil Hopper
-email  https://unfoldingword.org/contact/
+email  phillip_hopper@wycliffeassociates.org
 date   2015-05-20
-name   door43shared plugin
+name   Door43 Shared Plugin
 desc   Methods shared between door43 plugins
 url    https://github.com/Door43/dokuwiki-plugin-shared

--- a/lib/plugins/door43translation/plugin.info.txt
+++ b/lib/plugins/door43translation/plugin.info.txt
@@ -1,7 +1,7 @@
 base   door43translation
 author Phil Hopper
-email  https://unfoldingword.org/contact/
+email  phillip_hopper@wycliffeassociates.org
 date   2015-08-24
-name   door43translation plugin
+name   Door43 Translation Plugin
 desc   An extension of the translation plugin
 url    https://github.com/Door43/dokuwiki-plugin-shared


### PR DESCRIPTION
Change some of the plugin.info.txt files to be consistent with each other and to conform to the standards used in the plugins that ship with Dokuwiki.
