### PR TITLE
Add new link for check -> publish

### DIFF
--- a/lib/plugins/chunkprogress/utils.php
+++ b/lib/plugins/chunkprogress/utils.php
@@ -403,6 +403,19 @@ function generateDiffLinks($page_id) {
             . "&difftype=sidebyside|check-review]]";
     }
 
+    // Check -> Publish
+    if ($first_to_check != "(none)" and $first_to_publish != "(none)") {
+        if ($link_text != "") {
+            $link_text = $link_text . " | ";
+        }
+        $link_text = $link_text .
+            " [[$page_id?do=diff&rev2%5B0%5D="
+            . $first_to_check
+            . "&rev2%5B1%5D="
+            . $first_to_publish
+            . "&difftype=sidebyside|check-publish]]";
+    }
+
     // Review -> Publish
     if ($first_to_review != "(none)" and $first_to_publish != "(none)") {
         if ($link_text != "") {


### PR DESCRIPTION
This change adds a new link to the list of chunk links at the bottom of
certain pages.  If the page has a version tagged "check" and a version
tagged "publish", then a new "check-publish" link will appear that links to
the diff of those two versions.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/door43/385)

<!-- Reviewable:end -->
