### PR TITLE
[Door43] Remove Manager Link from Template (#107)

### DIFF
--- a/lib/plugins/door43publishrequest/_test/general.test.php
+++ b/lib/plugins/door43publishrequest/_test/general.test.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * General tests for the door43publishrequest plugin
+ *
+ * @group plugin_door43publishrequest
+ * @group plugins
+ */
+class general_plugin_door43publishrequest_test extends DokuWikiTest {
+
+    /**
+     * Simple test to make sure the plugin.info.txt is in correct format
+     */
+    public function test_plugininfo() {
+        $file = __DIR__.'/../plugin.info.txt';
+        $this->assertFileExists($file);
+
+        $info = confToHash($file);
+
+        $this->assertArrayHasKey('base', $info);
+        $this->assertArrayHasKey('author', $info);
+        $this->assertArrayHasKey('email', $info);
+        $this->assertArrayHasKey('date', $info);
+        $this->assertArrayHasKey('name', $info);
+        $this->assertArrayHasKey('desc', $info);
+        $this->assertArrayHasKey('url', $info);
+
+        $this->assertEquals('door43publishrequest', $info['base']);
+        $this->assertRegExp('/^https?:\/\//', $info['url']);
+        $this->assertTrue(mail_isvalid($info['email']));
+        $this->assertRegExp('/^\d\d\d\d-\d\d-\d\d$/', $info['date']);
+        $this->assertTrue(false !== strtotime($info['date']));
+    }
+}

--- a/lib/plugins/door43publishrequest/action.php
+++ b/lib/plugins/door43publishrequest/action.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * 
+ * 
+ * @author  Abi Gundy <abigundy@gmail.com>
+ * @date 11-18-2015
+ */
+
+// must be run within Dokuwiki
+if(!defined('DOKU_INC')) die();
+
+class action_plugin_door43publishrequest extends DokuWiki_Action_Plugin {
+
+    /**
+     * Registers a callback function for a given event
+     *
+     * @param Doku_Event_Handler $controller DokuWiki's event controller object
+     * @return void
+     */
+    public function register(Doku_Event_Handler $controller) {
+
+       $controller->register_hook('TEMPLATE_SITETOOLS_DISPLAY', 'BEFORE' , $this, 'handle_template_sitetools_display');
+   
+    }
+
+    /**
+     * [Custom event handler which performs action]
+     *
+     * @param Doku_Event $event  event object by reference
+     * @param mixed      $param  [the parameters passed as fifth argument to register_hook() when this
+     *                           handler was registered]
+     * @return void
+     */
+
+    public function handle_template_sitetools_display(Doku_Event &$event, $param) {
+        
+        $url = 'http://td.unfoldingword.org/publishing/publish/request/';
+        $out = '<a href="'.$url.'"><li>'.$this->getLang('publishRequest').'</li></a>';
+        echo $out;
+
+    }
+
+}
+

--- a/lib/plugins/door43publishrequest/lang/en/lang.php
+++ b/lib/plugins/door43publishrequest/lang/en/lang.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * Name: lang.php
+ * Description: The English language localization file for door43pubishreviewrequest plugin.
+ *
+ * Author: Abi Gundy
+ * Date:   2015-11-19
+ */
+
+// custom language strings for the plugin
+$lang['publishRequest'] = 'Publish Request Form';
+
+// error messages
+$lang['error'] = 'Unable to reach the publish request form page';

--- a/lib/plugins/door43publishrequest/plugin.info.txt
+++ b/lib/plugins/door43publishrequest/plugin.info.txt
@@ -1,0 +1,7 @@
+base   door43publishrequest
+author Abi Gundy
+email  abigundy@gmail.com
+date   2015-11-18
+name   Publish request form plugin
+desc   Links to the publish request form from sitetools in the header
+url    https://github.com/Door43/dokuwiki-plugin-door43-publish-request

--- a/lib/tpl/door43/tpl_header.php
+++ b/lib/tpl/door43/tpl_header.php
@@ -68,7 +68,6 @@ if (!defined('DOKU_INC')) die();
                 <?php
                     tpl_toolsevent('sitetools', array(
                         tpl_action('recent', true, 'li', true),
-                        tpl_action('media', true, 'li', true),
                         tpl_action('index', true, 'li', true)
                     ));
                 ?>


### PR DESCRIPTION
Added door43publishrequest plugin to add publish request form link to sitetools. Deleted line to remove media manager link from sitetools.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/door43/391)

<!-- Reviewable:end -->
