### PR TITLE
Fix word counts

### DIFF
--- a/lib/plugins/door43counts/action/GetWordCounts.php
+++ b/lib/plugins/door43counts/action/GetWordCounts.php
@@ -292,7 +292,7 @@ class action_plugin_door43counts_GetWordCounts extends Door43_Action_Plugin {
                 $usfm = preg_replace('/\\\\[v]\s\d+\s/', '', $usfm);
                 $usfm = preg_replace('/\\\\[c]\s\d+\s/', '', $usfm);
                 $usfm = preg_replace('/\\\\\S+\s/', '', $usfm);
-                $return_val[$resource['slug']] = str_word_count($usfm);
+                $return_val[substr($resource['slug'], 0, 3)] = str_word_count($usfm);
             }
 
             // get note word count, just once


### PR DESCRIPTION
The Bible word counts were not working because the directory name had changed

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/door43/462)

<!-- Reviewable:end -->
