### PR TITLE
door43gitmerge now handles the new naming convention of tS projects

### DIFF
--- a/lib/plugins/door43gitmerge/action.php
+++ b/lib/plugins/door43gitmerge/action.php
@@ -423,9 +423,16 @@ class action_plugin_door43gitmerge extends DokuWiki_Action_Plugin {
                             continue;
                         }
                         unset($file_parts);
-                        $file_parts = explode('-', substr($project_filename, 3));
-                        $project = array_shift($file_parts);
-                        $lang = implode('-', $file_parts);
+                        if(strpos($file, 'uw-') === 0){
+                            $file_parts = explode('-', substr($project_filename, 3));
+                            $project = array_shift($file_parts);
+                            $lang = implode('-', $file_parts);
+                        }
+                        else {
+                            $file_parts = explode('_', $file);
+                            $lang = $file_parts[0];
+                            $project = $file_parts[1];
+                        }
                         //list($project, $lang) = explode('-', substr($project_filename, 3));
                         $ids_path = $projects_path . $project_filename . '/';
                         $ids = scandir($ids_path);


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/door43/464)

<!-- Reviewable:end -->
